### PR TITLE
Fix bug with filename-only option

### DIFF
--- a/recipes/truststore.rb
+++ b/recipes/truststore.rb
@@ -48,7 +48,7 @@ end
 node['java-management']['truststore']['certificate_files'].each_pair do |certalias, options|
   java_management_truststore_certificate certalias do
     if options.is_a?(String)
-      file certificate_file
+      file options
     else
       file options['file']
       keystore options['keystore'] if options['keystore']


### PR DESCRIPTION
Hello,

Thanks for the recipe.  I ran into a an error when providing just a simple hash of 'certalias' -> 'filename' in my 'certificate_files' attribute. It's due to 'certificate_file' not being in scope at line 51. Looks like it's probably a copy/paste error. I fixed it and did a quick test in my environment. Thought you might want to know.
- Mike
